### PR TITLE
feat: add light theme support

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,4 +4,7 @@ export default antfu({
   stylistic: {
     semi: true,
   },
+  rules: {
+    'prefer-rest-params': 'warn',
+  },
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -471,8 +471,6 @@ const REFRESH_INTERVAL_SECONDS = 20; // 20 seconds
 const REFRESH_INTERVAL_KEY = 'refresh-interval';
 const TASK_SORT_ORDER_KEY = 'task-sort-order';
 const SHOW_COMPLETED_TASKS_KEY = 'show-completed-tasks';
-const COLOR_SCHEME_KEY = 'color-scheme';
-
 type TaskSortOrder = 'my-order' | 'date' | 'deadline' | 'starred-recently' | 'title';
 const VALID_TASK_SORT_ORDERS = new Set<TaskSortOrder>(['my-order', 'date', 'deadline', 'starred-recently', 'title']);
 
@@ -489,12 +487,9 @@ export default class GoogleTasksExtension extends Extension {
   private _taskLists: GoogleTaskList[] = [];
   private _activeTasksByListId: Map<string, GoogleTask[]> = new Map();
   private _completedTasksByListId: Map<string, GoogleTask[]> = new Map();
-  private _interfaceSettings: Gio.Settings | null = null;
-  private _colorSchemeChangedId: number | null = null;
 
   enable() {
     this._settings = this.getSettings();
-    this._interfaceSettings = this.getSettings('org.gnome.desktop.interface');
 
     this._tasksSection = new TasksSection();
     this._tasksManager = new GoogleTasksManager();
@@ -540,28 +535,8 @@ export default class GoogleTasksExtension extends Extension {
       });
     }
 
-    if (this._interfaceSettings) {
-      this._colorSchemeChangedId = this._interfaceSettings.connect(`changed::${COLOR_SCHEME_KEY}`, () => {
-        this._updateColorScheme();
-      });
-    }
-
-    this._updateColorScheme();
     this._refreshTasks();
     this._startRefreshTimer();
-  }
-
-  _updateColorScheme() {
-    if (!this._tasksSection || !this._interfaceSettings)
-      return;
-
-    const colorScheme = this._interfaceSettings.get_string(COLOR_SCHEME_KEY);
-    const isLight = colorScheme !== 'prefer-dark';
-
-    if (isLight)
-      this._tasksSection.add_style_class_name('google-tasks-light');
-    else
-      this._tasksSection.remove_style_class_name('google-tasks-light');
   }
 
   _getRefreshIntervalSeconds() {
@@ -862,12 +837,6 @@ export default class GoogleTasksExtension extends Extension {
       this._showCompletedChangedId = null;
     }
     this._settings = null;
-
-    if (this._interfaceSettings && this._colorSchemeChangedId !== null) {
-      this._interfaceSettings.disconnect(this._colorSchemeChangedId);
-      this._colorSchemeChangedId = null;
-    }
-    this._interfaceSettings = null;
 
     this._selectedTaskListId = null;
     this._taskLists = [];

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -11,22 +11,27 @@
 .task-radio {
     width: 12px;
     height: 12px;
-    border: 2px solid rgba(255, 255, 255, 0.6);
+    border: 2px solid rgba(128, 128, 128, 0.6);
     border-radius: 99px;
     background-color: transparent;
 }
 
 .task-radio:hover {
-    border-color: rgba(255, 255, 255, 0.9);
+    border-color: rgba(128, 128, 128, 0.9);
 }
 
 .task-radio-check {
-    color: rgba(255, 255, 255, 0.9);
+    opacity: 0.9;
 }
 
 .task-radio-completed {
-    background-color: rgba(255, 255, 255, 0.8);
-    border-color: rgba(255, 255, 255, 0.8);
+    background-color: rgba(128, 128, 128, 0.4);
+    border-color: rgba(128, 128, 128, 0.6);
+}
+
+.task-radio-completed:hover {
+    background-color: rgba(128, 128, 128, 0.5);
+    border-color: rgba(128, 128, 128, 0.7);
 }
 
 .task-label {
@@ -35,12 +40,12 @@
 
 .task-label-completed {
     text-decoration: line-through;
-    color: rgba(255, 255, 255, 0.4);
+    opacity: 0.4;
 }
 
 .task-description {
     font-size: 11px;
-    color: rgba(255, 255, 255, 0.4);
+    opacity: 0.4;
     margin-top: 1px;
 }
 
@@ -48,12 +53,12 @@
     border-radius: 8px;
     width: 28px;
     height: 28px;
-    color: rgba(255, 255, 255, 0.7);
+    opacity: 0.7;
 }
 
 .google-tasks-add-button:hover {
-    color: rgba(255, 255, 255, 1);
-    background-color: rgba(255, 255, 255, 0.1);
+    opacity: 1;
+    background-color: rgba(128, 128, 128, 0.3);
 }
 
 .google-tasks-dialog-title {
@@ -70,26 +75,25 @@
     border-radius: 6px;
     width: 20px;
     height: 20px;
-    color: rgba(255, 255, 255, 0.6);
+    opacity: 0.6;
 }
 
 .task-edit-button:hover {
-    color: rgba(255, 255, 255, 1);
-    background-color: rgba(255, 255, 255, 0.1);
+    opacity: 1;
+    background-color: rgba(128, 128, 128, 0.3);
 }
 
 .google-tasks-dropdown-button {
     padding: 6px 10px;
     border-radius: 8px;
-    color: rgba(255, 255, 255, 0.9);
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: rgba(128, 128, 128, 0.15);
     text-align: left;
     font-size: 13px;
     font-weight: 800;
 }
 
 .google-tasks-dropdown-button:hover {
-    background-color: rgba(255, 255, 255, 0.12);
+    background-color: rgba(128, 128, 128, 0.3);
 }
 
 .tasks-completed-toggle {
@@ -99,80 +103,19 @@
 }
 
 .tasks-completed-toggle:hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: rgba(128, 128, 128, 0.3);
 }
 
 .tasks-completed-label {
     font-size: 12px;
     font-weight: 700;
-    color: rgba(255, 255, 255, 0.7);
+    opacity: 0.7;
 }
 
 .tasks-completed-chevron {
-    color: rgba(255, 255, 255, 0.7);
+    opacity: 0.7;
 }
 
 .tasks-completed-list {
     padding-top: 2px;
-}
-
-
-.google-tasks-light .task-radio {
-    border-color: rgba(0, 0, 0, 0.5);
-}
-
-.google-tasks-light .task-radio:hover {
-    border-color: rgba(0, 0, 0, 0.9);
-}
-
-.google-tasks-light .task-radio-completed {
-    background-color: rgba(0, 0, 0, 0.2);
-    border-color: rgba(0, 0, 0, 0.6);
-}
-
-.google-tasks-light .task-label-completed {
-    color: rgba(0, 0, 0, 0.4);
-}
-
-.google-tasks-light .task-description {
-    color: rgba(0, 0, 0, 0.45);
-}
-
-.google-tasks-light .google-tasks-add-button {
-    color: rgba(0, 0, 0, 0.6);
-}
-
-.google-tasks-light .google-tasks-add-button:hover {
-    color: rgba(0, 0, 0, 0.9);
-    background-color: rgba(0, 0, 0, 0.08);
-}
-
-.google-tasks-light .task-edit-button {
-    color: rgba(0, 0, 0, 0.5);
-}
-
-.google-tasks-light .task-edit-button:hover {
-    color: rgba(0, 0, 0, 0.9);
-    background-color: rgba(0, 0, 0, 0.08);
-}
-
-.google-tasks-light .google-tasks-dropdown-button {
-    color: rgba(0, 0, 0, 0.8);
-    background-color: rgba(0, 0, 0, 0.06);
-}
-
-.google-tasks-light .google-tasks-dropdown-button:hover {
-    background-color: rgba(0, 0, 0, 0.1);
-}
-
-.google-tasks-light .tasks-completed-toggle:hover {
-    background-color: rgba(0, 0, 0, 0.06);
-}
-
-.google-tasks-light .tasks-completed-label {
-    color: rgba(0, 0, 0, 0.6);
-}
-
-.google-tasks-light .tasks-completed-chevron {
-    color: rgba(0, 0, 0, 0.6);
 }

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -116,3 +116,63 @@
     padding-top: 2px;
 }
 
+
+.google-tasks-light .task-radio {
+    border-color: rgba(0, 0, 0, 0.5);
+}
+
+.google-tasks-light .task-radio:hover {
+    border-color: rgba(0, 0, 0, 0.9);
+}
+
+.google-tasks-light .task-radio-completed {
+    background-color: rgba(0, 0, 0, 0.2);
+    border-color: rgba(0, 0, 0, 0.6);
+}
+
+.google-tasks-light .task-label-completed {
+    color: rgba(0, 0, 0, 0.4);
+}
+
+.google-tasks-light .task-description {
+    color: rgba(0, 0, 0, 0.45);
+}
+
+.google-tasks-light .google-tasks-add-button {
+    color: rgba(0, 0, 0, 0.6);
+}
+
+.google-tasks-light .google-tasks-add-button:hover {
+    color: rgba(0, 0, 0, 0.9);
+    background-color: rgba(0, 0, 0, 0.08);
+}
+
+.google-tasks-light .task-edit-button {
+    color: rgba(0, 0, 0, 0.5);
+}
+
+.google-tasks-light .task-edit-button:hover {
+    color: rgba(0, 0, 0, 0.9);
+    background-color: rgba(0, 0, 0, 0.08);
+}
+
+.google-tasks-light .google-tasks-dropdown-button {
+    color: rgba(0, 0, 0, 0.8);
+    background-color: rgba(0, 0, 0, 0.06);
+}
+
+.google-tasks-light .google-tasks-dropdown-button:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+.google-tasks-light .tasks-completed-toggle:hover {
+    background-color: rgba(0, 0, 0, 0.06);
+}
+
+.google-tasks-light .tasks-completed-label {
+    color: rgba(0, 0, 0, 0.6);
+}
+
+.google-tasks-light .tasks-completed-chevron {
+    color: rgba(0, 0, 0, 0.6);
+}


### PR DESCRIPTION
Hi. Thank you for such a useful extension. When using the white theme, I noticed an issue with white text displaying on a white background.

## Problem

All colors in `stylesheet.css` were hardcoded as `rgba(255, 255, 255, ...)`,
making text and controls invisible on a light background.

## Solution

- Added a `google-tasks-light` CSS class with dark-on-light color overrides
  for all styled elements (radio buttons, labels, descriptions, buttons,
  dropdown, completed section)
- In `extension.ts`, monitor `org.gnome.desktop.interface` → `color-scheme`
  via a separate `Gio.Settings` instance and toggle the CSS class on the
  root widget accordingly
- This requires a separate `Gio.Settings` file, since the standard `this._settings` scheme
   does not contain the `color-scheme` key - it belongs to `org.gnome.desktop.interface`
- The class is applied when `color-scheme` is not `prefer-dark`
  (i.e. both `default` and `prefer-light` are treated as light)